### PR TITLE
Update to taglib 2.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "taglib"]
 	path = taglib
-	url = https://github.com/timusus/taglib.git
+	url = https://github.com/taglib/taglib.git

--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="sample">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -15,7 +14,6 @@
             <option value="$PROJECT_DIR$/sample" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,19 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="56" name="Python" />
+      </Languages>
+    </inspection_tool>
+    <inspection_tool class="JniParameters" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N814" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyTypeHintsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="jbr-11" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,5 +3,6 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/taglib" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/taglib/3rdparty/utfcpp" vcs="Git" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.21"
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,7 +21,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version '3.10.2'
+            version '3.31.6'
             path 'src/main/cpp/CMakeLists.txt'
         }
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -49,7 +49,7 @@ afterEvaluate {
 
                 groupId = 'com.simplecityapps.ktaglib'
                 artifactId = 'ktaglib'
-                version = '1.4'
+                version = '1.5'
             }
         }
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -47,7 +47,7 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.release
 
-                groupId = 'com.simplecityapps.ktaglib'
+                groupId = 'com.github.timusus'
                 artifactId = 'ktaglib'
                 version = '1.5'
             }

--- a/lib/src/main/cpp/CMakeLists.txt
+++ b/lib/src/main/cpp/CMakeLists.txt
@@ -6,17 +6,15 @@ cmake_minimum_required(VERSION 3.10.2)
 # Project name
 project("ktaglib")
 
-add_subdirectory("../../../../taglib/taglib" taglib)
+add_subdirectory("../../../../taglib" taglib)
 
 add_library(ktaglib SHARED ktaglib.cpp)
+set_property(TARGET ktaglib PROPERTY CXX_STANDARD 17)
 
 find_library(log-lib log)
 target_link_libraries(ktaglib
         ${log-lib}
         tag)
-
-target_include_directories(tag PUBLIC
-        "../../../../taglib/3rdparty")
 
 target_include_directories(ktaglib PUBLIC
         "../../../../taglib/taglib"

--- a/lib/src/main/cpp/ktaglib.cpp
+++ b/lib/src/main/cpp/ktaglib.cpp
@@ -12,9 +12,8 @@
 #include <tstringlist.h>
 #include <toolkit/tiostream.h>
 #include <toolkit/tfilestream.h>
-#include <toolkit/tpicture.h>
 #include <toolkit/tmap.h>
-#include <toolkit/tpicturemap.h>
+#include <toolkit/tpropertymap.h>
 #include <toolkit/tdebuglistener.h>
 #include <android/log.h>
 
@@ -133,7 +132,7 @@ Java_com_simplecityapps_ktaglib_KTagLib_getMetadata(JNIEnv *env, jclass clazz, j
     auto stream = std::make_unique<TagLib::FileStream>(file_descriptor, true);
     TagLib::FileRef fileRef(stream.get());
 
-    if (fileRef.isValid()) {
+    if (!fileRef.isNull() && fileRef.tag()) {
         jobject jPropertyMap = env->NewObject(globalHashMapClass, hashMapInit);
 
         auto taglibProperties = fileRef.properties();
@@ -173,7 +172,7 @@ Java_com_simplecityapps_ktaglib_KTagLib_writeMetadata(JNIEnv *env, jclass clazz,
 
     jboolean isSuccessful = false;
 
-    if (fileRef.isValid()) {
+    if (!fileRef.isNull() && fileRef.tag()) {
         TagLib::PropertyMap taglibProperties = fileRef.properties();
         jobject entrySet = env->CallObjectMethod(properties, getEntrySet);
         jobject iterator = env->CallObjectMethod(entrySet, getIterator);
@@ -209,7 +208,7 @@ Java_com_simplecityapps_ktaglib_KTagLib_getArtwork(JNIEnv *env, jclass clazz, ji
 
     jbyteArray result = nullptr;
 
-    if (fileRef.isValid()) {
+    if (!fileRef.isNull()) {
         TagLib::ByteVector byteVector;
 
         if (auto *flacFile = dynamic_cast<TagLib::FLAC::File *>(fileRef.file())) {
@@ -242,17 +241,20 @@ Java_com_simplecityapps_ktaglib_KTagLib_getArtwork(JNIEnv *env, jclass clazz, ji
         } else {
             TagLib::Tag *tag = fileRef.tag();
             if (tag != nullptr) {
-                TagLib::PictureMap pictureMap = tag->pictures();
+                TagLib::List<TagLib::VariantMap> pictureMap = tag->complexProperties("PICTURE");
                 if (!pictureMap.isEmpty()) {
                     // Finds the largest picture by byte size
                     size_t picSize = 0;
-                    for (auto const &pair: pictureMap) {
-                        for (auto const &i: pair.second) {
-                            size_t size = i.data().size();
-                            if (size > picSize) {
-                                byteVector = i.data();
+                    for (auto const &property: pictureMap) {
+                        for (auto const &[key, value]: property) {
+                            if (value.type() == TagLib::Variant::ByteVector) {
+                                auto i = value.value<TagLib::ByteVector>();
+                                size_t size = i.size();
+                                if (size > picSize) {
+                                    byteVector = i;
+                                    picSize = size;
+                                }
                             }
-                            picSize = size;
                         }
                     }
                 }


### PR DESCRIPTION
This seems to work (both in the test application and S2), but probably should be tested a bit more before merging/releasing. It might make sense to rebase timusus/taglib instead of switching to upstream, but I'm not sure if those patches are still relevant. The biggest benefit of this update is adding ReplayGain support for .m4a files. 